### PR TITLE
Allow pre-commit to manage its dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,29 +13,32 @@ repos:
       - id: end-of-file-fixer
         exclude: LICENSE
 
-  - repo: local
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.31.1
     hooks:
       # Upgrade outdated python syntax
       - id: pyupgrade
         name: pyupgrade
-        entry: poetry run pyupgrade --py38-plus
+        entry: pyupgrade --py38-plus
         types: [python]
-        language: system
+        language: python
 
-  - repo: local
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
     hooks:
       # Sort ordering of python imports
       - id: isort
         name: isort
-        entry: poetry run isort --settings-path pyproject.toml
+        entry: isort --settings-path pyproject.toml
         types: [python]
-        language: system
+        language: python
 
-  - repo: local
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
     hooks:
       # Run code formatting on python code
       - id: black
         name: black
-        entry: poetry run black --config pyproject.toml
+        entry: black --config pyproject.toml
         types: [python]
-        language: system
+        language: python


### PR DESCRIPTION
Sometimes pre-commit doesn't want to work properly. Recommendation from the library maintainer is to not use `language: system` (https://github.com/pre-commit/pre-commit/issues/1465#issuecomment-632786386)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If there's a Figma file or similar spec, please link to to the issue. -->

## How Can It Be Tested?
<!--- Please describe in detail how you tested your changes so that a reviewer can reproduce the results. -->
<!--- Include details of your testing environment, and the tests you've run your self -->
<!--- see how your change affects other areas of the code, etc. -->

## How Will This Be Deployed?
<!--- Run through any change to infrastructure, CLI commands or manual admin config to do -->
<!--- For example, any env variables to add to the hosting infra? -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've checked the spec (e.g. Figma file) and documented any divergences.
- [ ] My code follows the code style of this project.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I've updated the documentation accordingly.
- [ ] Replace unused checkboxes with bullet points.